### PR TITLE
added support for actions on multiple selection in tree

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
@@ -15,9 +15,6 @@ import com.intellij.openapi.util.Key;
 
 public class CommonConstants {
     public static final String HOME_FOLDER = System.getProperty("user.home");
-
     public static final Key<Project> PROJECT = Key.create("com.redhat.devtools.intellij.common.project");
     public static final Key<Long> LAST_MODIFICATION_STAMP = Key.create("com.redhat.devtools.intellij.common.last.modification.stamp");
-
-    public static final Key<Boolean> TREE_MULTIPLE_SELECTION = Key.create("com.redhat.devtools.intellij.common.tree.multiple.selection");
 }

--- a/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
@@ -19,4 +19,5 @@ public class CommonConstants {
     public static final Key<Project> PROJECT = Key.create("com.redhat.devtools.intellij.common.project");
     public static final Key<Long> LAST_MODIFICATION_STAMP = Key.create("com.redhat.devtools.intellij.common.last.modification.stamp");
 
+    public static final Key<Boolean> TREE_MULTIPLE_SELECTION = Key.create("com.redhat.devtools.intellij.common.tree.multiple.selection");
 }

--- a/src/main/java/com/redhat/devtools/intellij/common/actions/StructureTreeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/actions/StructureTreeAction.java
@@ -19,8 +19,8 @@ public abstract class StructureTreeAction extends TreeAction {
         super(filters);
     }
 
-    public StructureTreeAction(boolean multipleSelection, Class... filters) {
-        super(multipleSelection, filters);
+    public StructureTreeAction(boolean acceptMultipleItems, Class... filters) {
+        super(acceptMultipleItems, filters);
     }
 
     public static <T> T getElement(Object selected) {

--- a/src/main/java/com/redhat/devtools/intellij/common/actions/StructureTreeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/actions/StructureTreeAction.java
@@ -19,6 +19,10 @@ public abstract class StructureTreeAction extends TreeAction {
         super(filters);
     }
 
+    public StructureTreeAction(boolean multipleSelection, Class... filters) {
+        super(multipleSelection, filters);
+    }
+
     public static <T> T getElement(Object selected) {
         if (selected instanceof DefaultMutableTreeNode) {
             selected = ((DefaultMutableTreeNode)selected).getUserObject();

--- a/src/main/java/com/redhat/devtools/intellij/common/actions/TreeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/actions/TreeAction.java
@@ -17,11 +17,8 @@ import com.intellij.ui.treeStructure.Tree;
 
 import javax.swing.tree.TreePath;
 import java.awt.Component;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.stream.Stream;
-
-import static com.redhat.devtools.intellij.common.CommonConstants.TREE_MULTIPLE_SELECTION;
 
 public abstract class TreeAction extends AnAction {
 
@@ -68,10 +65,7 @@ public abstract class TreeAction extends AnAction {
         Component comp = getTree(e);
 
         if (comp instanceof Tree) {
-            boolean treeMultipleSelectionEnabled = ((Tree) comp).getClientProperty(TREE_MULTIPLE_SELECTION) == null ?
-                                                    false :
-                                                    (boolean) ((Tree) comp).getClientProperty(TREE_MULTIPLE_SELECTION);
-            visible = isVisible(treeMultipleSelectionEnabled, getSelectedNodes((Tree) comp));
+            visible = isVisible(getSelectedNodes((Tree) comp));
         }
         e.getPresentation().setVisible(visible);
     }
@@ -80,11 +74,7 @@ public abstract class TreeAction extends AnAction {
         return Stream.of(filters).anyMatch(cl -> cl.isAssignableFrom(selected.getClass()));
     }
 
-    public boolean isVisible(boolean treeMultipleSelectionEnabled, Object[] selected) {
-        if (!treeMultipleSelectionEnabled) {
-            return isVisible(adjust(selected[0]));
-        }
-
+    public boolean isVisible(Object[] selected) {
         if (!acceptMultipleItems && selected.length > 1) {
             return false;
         }
@@ -102,11 +92,7 @@ public abstract class TreeAction extends AnAction {
         Tree tree = getTree(anActionEvent);
         TreePath[] selectedPaths = tree.getSelectionModel().getSelectionPaths();
         Object[] selected = getSelectedNodes(tree);
-        if (acceptMultipleItems) {
-            actionPerformed(anActionEvent, selectedPaths, selected);
-        } else {
-            actionPerformed(anActionEvent, selectedPaths[0], selected[0]);
-        }
+        actionPerformed(anActionEvent, selectedPaths, selected);
     }
 
     public abstract void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected);


### PR DESCRIPTION
This is linked with https://github.com/redhat-developer/intellij-tekton/issues/83

This patch adds support for multiple selection in a tree and make actions appear/work when multiple items are selected.
Until now if you selected multiple items only the first one was taken as arg for an action.
To change the behavior, first you need to setup a property `TREE_MULTIPLE_SELECTION` to true in the tree and then add a property `acceptMultipleItems` for each action you want to handle multiple items. This way the context menu will show only the possible actions.

If nothing is set up it works exactly as before so the other extensions that use this library can also maintain their current code.

An example below.

This is when only one item is selected, the context menu contains everything as before.

![image](https://user-images.githubusercontent.com/49404737/83891305-3a42d400-a74d-11ea-8342-9ab2e48d608e.png)

This is when more than one item is selected, only the actions that accept more than one items and can be executed on all items are shown.

![image](https://user-images.githubusercontent.com/49404737/83891366-53e41b80-a74d-11ea-8fd3-94174bd7c177.png)

Here we have nodes of two different types and because the delete action doesn't work with the PipelineNode it isn't shown.

![image](https://user-images.githubusercontent.com/49404737/83891509-90b01280-a74d-11ea-8a45-142693a9f3eb.png)







