### PR TITLE
Do not uncompress downloaded file if it not an archive

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/DownloadHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/DownloadHelper.java
@@ -243,9 +243,14 @@ public class DownloadHelper {
                     save(subStream, cmd.resolveSibling(entry.getName()), entry.getSize());
                 }
             } else {
+                // we already has cmd downloaded, so just set executable bit
+                if(cmd.equals(dlFilePath)) {
+                    cmd.toFile().setExecutable(true);
+                    return;
+                }
                 save(subStream, cmd, -1L);
             }
-            } catch (RuntimeException e) {
+        } catch (RuntimeException e) {
             throw new IOException(e);
         }
     }

--- a/src/test/java/com/redhat/devtools/intellij/common/utils/DownloadHelperTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/common/utils/DownloadHelperTest.java
@@ -36,4 +36,11 @@ public class DownloadHelperTest extends LightPlatformTestCase {
         assertEquals("." + File.separatorChar + "cache" + File.separatorChar + "0.5.0" + File.separatorChar + "tkn", cmd);
         assertEquals(17, new File(cmd).length());
     }
+
+    public void testThatPlainFileDownloaded() throws IOException{
+        String cmd = DownloadHelper.getInstance().downloadIfRequired("kn", DownloadHelperTest.class.getResource("/knative-test.json"));
+        assertNotNull(cmd);
+        assertEquals("." + File.separatorChar + "cache" + File.separatorChar + "0.5.0" + File.separatorChar + "tkn", cmd);
+        assertEquals(17, new File(cmd).length());
+    }
 }

--- a/src/test/resources/knative-test.json
+++ b/src/test/resources/knative-test.json
@@ -1,0 +1,29 @@
+{
+  "tools": {
+    "kn": {
+      "version": "0.5.0",
+      "versionCmd": "version",
+      "versionExtractRegExp": "Client version: (\\d+[\\.\\d+]*)\\s.*",
+      "versionMatchRegExpr": "0\\..*",
+      "baseDir": ".",
+      "platforms": {
+        "win": {
+          "url": "file:src/test/resources/tkn",
+          "cmdFileName": "tkn",
+          "dlFileName": "tkn"
+        },
+        "osx": {
+          "url": "file:src/test/resources/tkn",
+          "cmdFileName": "tkn",
+          "dlFileName": "tkn"
+        },
+        "lnx": {
+          "url": "file:src/test/resources/tkn",
+          "cmdFileName": "tkn",
+          "dlFileName": "tkn"
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION

When `dlFileName` and `cmdFileName` are the same, without this fix we open input and output stream on same file which lead to breaking file content. 
It is a blocker for https://github.com/redhat-developer/intellij-knative/issues/1 as `kn` CLI released as plain binnary. 