### PR TITLE
Listeners + helpers in common between Tekton/Knative

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
@@ -17,4 +17,5 @@ public class CommonConstants {
     public static final String HOME_FOLDER = System.getProperty("user.home");
     public static final Key<Project> PROJECT = Key.create("com.redhat.devtools.intellij.common.project");
     public static final Key<Long> LAST_MODIFICATION_STAMP = Key.create("com.redhat.devtools.intellij.common.last.modification.stamp");
+    public static final Key<Object> TARGET_NODE = Key.create("com.redhat.devtools.intellij.common.targetnode");
 }

--- a/src/main/java/com/redhat/devtools/intellij/common/listener/SaveInEditorListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/listener/SaveInEditorListener.java
@@ -62,7 +62,6 @@ public abstract class SaveInEditorListener extends FileDocumentSynchronizationVe
     protected boolean isFileToPush(Project project, VirtualFile vf) {
         FileEditor selectedEditor = FileEditorManager.getInstance(project).getSelectedEditor();
         // if file is not the one selected, skip it
-        if (selectedEditor == null || vf == null || !selectedEditor.getFile().equals(vf)) return false;
-        return true;
+        return !(selectedEditor == null || !selectedEditor.getFile().equals(vf));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/common/listener/SaveInEditorListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/listener/SaveInEditorListener.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.common.listener;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileDocumentSynchronizationVetoer;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import java.io.IOException;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static com.redhat.devtools.intellij.common.CommonConstants.LAST_MODIFICATION_STAMP;
+import static com.redhat.devtools.intellij.common.CommonConstants.PROJECT;
+import static com.redhat.devtools.intellij.common.CommonConstants.TARGET_NODE;
+
+public abstract class SaveInEditorListener extends FileDocumentSynchronizationVetoer {
+    @Override
+    public boolean maySaveDocument(@NotNull Document document, boolean isSaveExplicit) {
+        VirtualFile vf = FileDocumentManager.getInstance().getFile(document);
+        Project project = vf.getUserData(PROJECT);
+        Long lastModificationStamp = vf.getUserData(LAST_MODIFICATION_STAMP);
+        Long currentModificationStamp = document.getModificationStamp();
+        if (project == null ||
+                !isFileToPush(project, vf) ||
+                currentModificationStamp.equals(lastModificationStamp)
+        ) {
+            return true;
+        }
+
+        vf.putUserData(LAST_MODIFICATION_STAMP, currentModificationStamp);
+        if (save(document, project)) {
+            notify(document);
+            refresh(project, vf.getUserData(TARGET_NODE));
+        }
+        return false;
+    }
+
+    protected abstract void notify(Document document);
+
+    protected abstract void refresh(Project project, Object node);
+
+    protected abstract boolean save(Document document, Project project);
+
+    protected boolean isFileToPush(Project project, VirtualFile vf) {
+        FileEditor selectedEditor = FileEditorManager.getInstance(project).getSelectedEditor();
+        // if file is not the one selected, skip it
+        if (selectedEditor == null || vf == null || !selectedEditor.getFile().equals(vf)) return false;
+        return true;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/common/listener/TreeDoubleClickListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/listener/TreeDoubleClickListener.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.common.listener;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.DoubleClickListener;
+import com.intellij.util.ui.tree.WideSelectionTreeUI;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.JTree;
+import javax.swing.tree.TreePath;
+import java.awt.event.MouseEvent;
+
+
+public abstract class TreeDoubleClickListener extends DoubleClickListener {
+    private final JTree tree;
+
+    public TreeDoubleClickListener(final JTree tree) {
+        this.tree = tree;
+        installOn(tree);
+    }
+
+
+    @Override
+    protected boolean onDoubleClick(MouseEvent event) {
+        final TreePath clickPath = tree.getUI() instanceof WideSelectionTreeUI ? tree.getClosestPathForLocation(event.getX(), event.getY())
+                : tree.getPathForLocation(event.getX(), event.getY());
+        if (clickPath == null) {
+            return false;
+        }
+
+        final DataContext dataContext = DataManager.getInstance().getDataContext(tree);
+        final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+        if (project == null) {
+            return false;
+        }
+
+        TreePath selectionPath = tree.getSelectionPath();
+        if (!clickPath.equals(selectionPath)) {
+            return false;
+        }
+
+        if (event.getClickCount() == 2) {
+            processDoubleClick(selectionPath);
+            return true;
+        }
+        return false;
+    }
+
+    protected abstract void processDoubleClick(@NotNull TreePath treePath);
+}

--- a/src/main/java/com/redhat/devtools/intellij/common/listener/TreePopupMenuListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/listener/TreePopupMenuListener.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.common.listener;
+
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+public class TreePopupMenuListener implements PopupMenuListener {
+    private static boolean isMenuVisible = false;
+
+    public static boolean isTreeMenuVisible() {
+        return isMenuVisible;
+    }
+
+    @Override
+    public void popupMenuWillBecomeVisible(PopupMenuEvent popupMenuEvent) {
+        isMenuVisible = true;
+    }
+
+    @Override
+    public void popupMenuWillBecomeInvisible(PopupMenuEvent popupMenuEvent) {
+        isMenuVisible = false;
+    }
+
+    @Override
+    public void popupMenuCanceled(PopupMenuEvent popupMenuEvent) {
+        isMenuVisible = false;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/common/utils/DeployModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/DeployModel.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.common.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+
+public class DeployModel {
+    private String name, apiVersion, kind;
+    private JsonNode spec;
+    private CustomResourceDefinitionContext crdContext;
+
+    public DeployModel(String name, String kind, String apiVersion, JsonNode spec, CustomResourceDefinitionContext crdContext) {
+        this.name = name;
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.spec = spec;
+        this.crdContext = crdContext;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public JsonNode getSpec() {
+        return spec;
+    }
+
+    public void setSpec(JsonNode spec) {
+        this.spec = spec;
+    }
+
+    public CustomResourceDefinitionContext getCrdContext() {
+        return crdContext;
+    }
+
+    public void setCrdContext(CustomResourceDefinitionContext crdContext) {
+        this.crdContext = crdContext;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/common/utils/VirtualFileHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/VirtualFileHelper.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.common.utils;
+
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.apache.commons.io.FileUtils;
+
+public class VirtualFileHelper {
+    public static VirtualFile createTempFile(String name, String content) throws IOException {
+        File file = new File(System.getProperty("java.io.tmpdir"), name);
+        if (file.exists()){
+            file.delete();
+            LocalFileSystem.getInstance().refreshIoFiles(Arrays.asList(file));
+        }
+        FileUtils.write(file, content, StandardCharsets.UTF_8);
+        file.deleteOnExit();
+        return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+    }
+}


### PR DESCRIPTION
This patch adds tools to work with files and tree (save file from the editor, double click on the tree, tree menu popup ...) used in tekton and knative plugins