### PR TITLE
add create kind to watchservice

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ConfigWatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ConfigWatcher.java
@@ -84,6 +84,7 @@ public class ConfigWatcher implements Runnable {
         HighSensitivityRegistrar modifier = new HighSensitivityRegistrar();
         modifier.registerService(getWatchedPath(),
                 new WatchEvent.Kind[]{
+                        StandardWatchEventKinds.ENTRY_CREATE,
                         StandardWatchEventKinds.ENTRY_MODIFY,
                         StandardWatchEventKinds.ENTRY_DELETE},
                 service);


### PR DESCRIPTION
This fixes a possible issue you face due to some editor behavior (e.g gedit).
In some editor, when you edit the file, the editor creates a new temp file, edit it and then use it to recreate the original file so if you only listen to the edit/delete action nothing happens and the plugins are never refreshed.