### PR TITLE
Add new 'executeWithResult' method

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ExecHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ExecHelper.java
@@ -64,9 +64,9 @@ public class ExecHelper {
   }
 
   /**
-   * @deprecated As it combines and returns out and err streams, use {@link #executeWithResult(String, boolean, File, Map, String...)} instead
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
    */
-  @Deprecated
   public static String execute(String executable, boolean checkExitCode, File workingDirectory, Map<String,String> envs,
                                String... arguments) throws IOException {
     DefaultExecutor executor = new DefaultExecutor() {
@@ -94,33 +94,50 @@ public class ExecHelper {
     }
   }
 
-  @Deprecated
+  /**
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
+   */
   public static String execute(String executable, File workingDirectory, Map<String, String> envs, String... arguments) throws IOException {
     return execute(executable, true, workingDirectory, envs, arguments);
   }
 
-  @Deprecated
+  /**
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
+   */
   public static String execute(String executable, Map<String, String> envs, String... arguments) throws IOException {
     return execute(executable, true, new File(HOME_FOLDER), envs, arguments);
   }
-
-  @Deprecated
+  /**
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
+   */
   public static String execute(String executable, String... arguments) throws IOException {
     return execute(executable, Collections.emptyMap(), arguments);
   }
 
-  @Deprecated
+  /**
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
+   */
   public static String execute(String executable, File workingDirectory, String... arguments) throws IOException {
     return execute(executable, true, workingDirectory, Collections.emptyMap(), arguments);
   }
 
-  @Deprecated
+  /**
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
+   */
   public static String execute(String executable, boolean checkExitCode, Map<String, String> envs,
                                String... arguments) throws IOException {
     return execute(executable, checkExitCode, new File(HOME_FOLDER), envs, arguments);
   }
 
-  @Deprecated
+  /**
+   * This method combine <b>out</b> and <b>err</b> outputs in result string, if you need to have them separately
+   *  use @link {@link #executeWithResult(String, boolean, File, Map, String...)}
+   */
   public static String execute(String executable, boolean checkExitCode, String... arguments) throws IOException {
     return execute(executable, checkExitCode, new File(HOME_FOLDER), Collections.emptyMap(), arguments);
   }


### PR DESCRIPTION
During work on https://github.com/redhat-developer/intellij-knative/issues/38 I found that `kn` cli can print some errors/warnings for some kommand in `stderr` stream. Existing `execute` method combines `sdtout` and `stderr` streams in to one string which we trying to parse as JSON, which fails as string not contain valid JSON.

This PR just add new method `executeWithResult` which return object with `sdtout` and `stderr` placed separately.

I not 100% sure how to properly fix existing methods, as do not want to break other code, so I just deprecate `execute` methods. Other option can be change `execute`  to use two streams for `sdtout` and `stderr`. But I not sure what we need to do with `stderr` in such case.

It blocker for https://github.com/redhat-developer/intellij-knative/issues/38