### PR TITLE
chore: add plugin verifier to github actions (#101)

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -27,3 +27,23 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build -PideaVersion=${{ matrix.IJ }}
 
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew runPluginVerifier -PideaVersion=IC-2021.2
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: verifier-report
+          path: build/reports/pluginVerifier

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ def testArtifact = artifacts.add('archives', testJarFile) {
     builtBy 'packageTests'
 }
 
+runPluginVerifier {
+    ideVersions = [ideaVersion]
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {


### PR DESCRIPTION
depends on #100 which needs to be merged first (`runPluginVerifier` only exists with intellij gradle plugin 1.1.4)
fixes #101