### PR TITLE
fix: Graceful termination for terminal runs

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ExecProcessHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ExecProcessHandler.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.common.utils;
 
+import com.intellij.execution.process.KillableProcessHandler;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.util.io.BaseDataReader;
 import com.intellij.util.io.BaseOutputReader;
@@ -18,7 +19,7 @@ import java.nio.charset.Charset;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ExecProcessHandler extends OSProcessHandler {
+public class ExecProcessHandler extends KillableProcessHandler {
 
     /**
      *


### PR DESCRIPTION
When not extending `KillableProcessHandler` the stop action (the 🟥 button) will SIGKILL to the console app.
When extending `KillableProcessHandler` it will send `SIGINT` or `SIGTERM` first giving opportunity to clean up.

resolves #135