### PR TITLE
feat: support different os architectures when downloading

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/DownloadHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/DownloadHelper.java
@@ -154,13 +154,10 @@ public class DownloadHelper {
     }
 
     private ToolsConfig.Platform getPlatformBasedOnOs(ToolsConfig.Tool tool) {
-        String osArch = System.getProperty("os.arch");
+        String osArch = Platform.arch().toString();
         String osId = Platform.os().id();
-        if (osArch != null
-            && tool.getPlatforms().containsKey(osId + "-" + osArch)) {
+        if (tool.getPlatforms().containsKey(osId + "-" + osArch)) {
                 return tool.getPlatforms().get(osId + "-" + osArch);
-        } else if ("arm64".equals(osArch)) {
-            return null;
         }
         return tool.getPlatforms().get(osId);
 


### PR DESCRIPTION
This is needed so that we can add different versions of a CLI for darwin in our configuration files. MAC M1 needs arm64 versions to work.

This is only made to correctly behaves with arm64/amd64. If it happens that someone uses s390x, ppc64le or some weird os arch  it still executes as before. Not sure if we need to handle everything.