### PR TITLE
fix: add back executeWithTerminal method signature deleted wrongly

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ExecHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ExecHelper.java
@@ -406,6 +406,10 @@ public class ExecHelper {
     executeWithTerminal(project, title, new File(HOME_FOLDER), true, Collections.emptyMap(), null, null, null, command);
   }
 
+  public static void executeWithTerminal(Project project, String title, File workingDirectory, boolean waitForProcessToExit, Map<String, String> envs, String... command) throws IOException {
+    executeWithTerminal(project, title, workingDirectory, waitForProcessToExit, envs, null, null, null, command);
+  }
+
   public static void executeWithTerminal(Project project, String title, Map<String, String> envs, ConsoleView terminalToReuse, String... command) throws IOException {
     executeWithTerminal(project, title, new File(HOME_FOLDER), true, envs, terminalToReuse, null, null, command);
   }


### PR DESCRIPTION
fixes #148 

This is required by openshift connector -> https://github.com/redhat-developer/intellij-openshift-connector/pull/425

Is this the only one missing right?