### PR TITLE
chore: release 1.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion = IC-2021.1
-projectVersion=1.8.0-SNAPSHOT
+projectVersion=1.7.1
 nexusUser=invalid
 nexusPassword=invalid


### PR DESCRIPTION
we need to release a new version of intellij-openshift-connector. See [chore: bumped openshift-client 5.12.2 & intellij-common 1.7.1](https://github.com/redhat-developer/intellij-openshift-connector/pull/425/files#)
This should be 1.7.1 though since none of the commits since 1.7.0 would break the API (a method was added: https://github.com/redhat-developer/intellij-common/issues/148)
@jeffmaury, @lstocchi: thoughts? 