### PR TITLE
chore: extracted methods for YAML clutter removal from VirutalFileHelper

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/CommonConstants.java
@@ -23,6 +23,12 @@ public class CommonConstants {
     public static final Key<String> CONTENT = Key.create("com.redhat.devtools.intellij.common.content");
     public static final Key<Boolean> CLEANED = Key.create("com.redhat.devtools.intellij.common.cleaned");
 
+    /**
+     * Properties in {@link io.fabric8.kubernetes.api.model.ObjectMeta} that are considered disposable clutter.
+     *
+     * @deprecated since 1.8.0, use {@link com.redhat.devtools.intellij.common.utils.ObjectMetadataClutter#properties} instead
+     */
+    @Deprecated
     public static final List<String> metadataClutter = Arrays.asList(
             "clusterName",
             "creationTimestamp",

--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ObjectMetadataClutter.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ObjectMetadataClutter.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.common.utils;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class ObjectMetadataClutter {
+    private static final Logger logger = LoggerFactory.getLogger(ObjectMetadataClutter.class);
+
+    /**
+     * Properties in {@link io.fabric8.kubernetes.api.model.ObjectMeta} that are considered disposable clutter.
+     */
+    public static final List<String> properties = Arrays.asList(
+            "clusterName",
+            "creationTimestamp",
+            "deletionGracePeriodSeconds",
+            "deletionTimestamp",
+            "finalizers",
+            "generation",
+            "managedFields",
+            "ownerReferences",
+            "resourceVersion",
+            "selfLink",
+            "uid"
+    );
+
+    private static final String PROPERTY_METADATA = "metadata";
+
+    /**
+     * Removes clutter properties from the given content. Does nothing if the content is {@code null} or empty.
+     *
+     * @param resource where the clutter properties should be removed from
+     * @return the content without the clutter properties
+     */
+    public static String remove(String resource) {
+        if (resource == null
+                || resource.isEmpty()) {
+            return resource;
+        }
+
+        try {
+            ObjectNode contentNode = (ObjectNode) YAMLHelper.YAMLToJsonNode(resource);
+            ObjectNode metadata = contentNode.has(PROPERTY_METADATA) ? (ObjectNode) contentNode.get(PROPERTY_METADATA) : null;
+            if (metadata != null) {
+                metadata.remove(properties);
+                contentNode.set(PROPERTY_METADATA, metadata);
+                resource = YAMLHelper.JSONToYAML(contentNode);
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage(), e);
+        }
+        return resource;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/common/utils/VirtualFileHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/VirtualFileHelper.java
@@ -38,6 +38,16 @@ public class VirtualFileHelper {
         return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
     }
 
+    /**
+     * Removes the clutter properties {@link com.redhat.devtools.intellij.common.CommonConstants#metadataClutter} from the given resource.
+     *
+     * @param content
+     * @return the content without the clutter properties
+     *
+     * @deprecated
+     * Deprecated since 1.8.0, use {@link ObjectMetadataClutter#remove(String)} instead.
+     */
+    @Deprecated
     public static String cleanContent(String content) {
         if (content.isEmpty()) {
             return content;

--- a/src/main/java/com/redhat/devtools/intellij/common/utils/YAMLHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/YAMLHelper.java
@@ -55,6 +55,7 @@ public class YAMLHelper {
     public static JsonNode getValueFromYAML(String yamlAsString, String[] path) throws IOException {
         if (yamlAsString == null) return null;
         JsonNode node = YAML_MAPPER.readTree(yamlAsString);
+        Pattern arrayPattern = Pattern.compile("(\\w+)(\\[(\\d)\\])*");
         for (String field: path) {
             Property property = createProperty(field, node);
             if (!property.existsIn(node)) {
@@ -106,14 +107,14 @@ public class YAMLHelper {
         } else {
             JsonNode node = YAML_MAPPER.readTree(yamlAsString);
             JsonNode tmpNode = node;
-
             for (int i = 0; i < fieldnames.length; ++i) {
                 Property property = createProperty(fieldnames[i], tmpNode);
                 if (!property.existsIn(tmpNode)) {
                     return null;
                 }
+
                 if (i == fieldnames.length - 1) {
-                    ((ObjectNode) tmpNode).put(property.getName(), value);
+                    ((ObjectNode) tmpNode).put(fieldnames[i], value);
                 } else {
                     tmpNode = property.getNodeIn(tmpNode);
                 }
@@ -241,5 +242,4 @@ public class YAMLHelper {
         }
 
     }
-
 }


### PR DESCRIPTION
moved the method for YAML clutter cleanup from `VirtualFileHelper` to it's own class. IMHO this is better when it comes to separation of concerns. I kept the original methods and marked them as deprecated for smoother migration of existing consumers.
This is to prepare the next step where I add support for JSON (it currently only supports YAML)