### PR TITLE
chore(skip-release): remove run step from release workflow for printing out changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           current-tag: ${{ steps.get_version.outputs.VERSION }}
           types-mapping: 'feat:Features,fix:Bug Fixes,docs:Documentation,refactor:Refactoring,build:Builds,chore:Other'
           scopes-mapping: 'UI:UI,Hub:Hub'
-      - run: |
-          echo '${{ steps.changelog.outputs.changelog }}'
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
The last release workflow failed because of this step. It already happened in other repos.
I'm removing it as this is not really necessary, it was there just to see the output and check if everything was working fine.