### PR TITLE
fix: report that loading tools.json failed (was: jackson error)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ConfigHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ConfigHelper.java
@@ -77,7 +77,11 @@ public class ConfigHelper {
     }
 
     public static ToolsConfig loadToolsConfig(URL url) throws IOException {
-        return mapper.readValue(url, ToolsConfig.class);
+        try {
+            return mapper.readValue(url, ToolsConfig.class);
+        } catch (IOException e) {
+            throw new IOException("Could not load tools config at " + url.toString() + ": " + e.getMessage(), e);
+        }
     }
 
     public static NamedContext getCurrentContext() {


### PR DESCRIPTION
without this fix, when a corrupt `tools.json` is loaded the user gets a cryptic jackson mapper error. 
With the fix:
<img width="614" alt="image" src="https://github.com/redhat-developer/intellij-common/assets/25126/e6eb1b81-64c5-48c4-abf0-24bfe64f1434">
