### PR TITLE
fix: ignore unknown properties when unmarshalling ToolsConfig

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ConfigHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ConfigHelper.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.common.utils;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.AuthInfo;

--- a/src/main/java/com/redhat/devtools/intellij/common/utils/ToolsConfig.java
+++ b/src/main/java/com/redhat/devtools/intellij/common/utils/ToolsConfig.java
@@ -18,6 +18,8 @@ import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ToolsConfig {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Tool {
     private Map<String, Platform> platforms = new HashMap<>();
 
@@ -85,6 +87,7 @@ public class ToolsConfig {
     }
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Platform {
     private URL url;
     private String cmdFileName;


### PR DESCRIPTION
`ToolsConfig` is annotated with `@JsonIgnoreProperties(ignoreUnknown = true)` but it's missing from `Tools` and jackson thus throws `UnrecognizedPropertyException` when a tool in `tools.json` contains unknown properties.

To reproduce add `description` property to `odo` in `tools.json` or simply copy `tools.json` over from vscode-openshift-tools (https://github.com/redhat-developer/vscode-openshift-tools/blob/main/src/tools.json#L3C9-L3C34):

```json
    "tools": {
       "odo": {
            "description": "odo CLI",
```