### PR TITLE
chore(skip-release): prepare 1.9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
-    - uses: actions/upload-artifact@v1
-      if: always()
+    - uses: actions/upload-artifact@v4
       with:
         name: linux-test-reports
         path: build/reports
@@ -42,8 +41,7 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
-    - uses: actions/upload-artifact@v1
-      if: always()
+    - uses: actions/upload-artifact@v4
       with:
         name: macos-test-reports
         path: build/reports
@@ -61,8 +59,7 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
-    - uses: actions/upload-artifact@v1
-      if: always()
+    - uses: actions/upload-artifact@v4
       with:
         name: windows-test-reports
         path: build/reports

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion=IC-2024.1
-projectVersion=1.9.6-SNAPSHOT
+projectVersion=1.9.6
 nexusUser=invalid
 nexusPassword=invalid


### PR DESCRIPTION
fixes #234 

for https://github.com/redhat-developer/intellij-kubernetes/pull/781 I'll update `ConfigWatcher`. Before this change I want to release intellij-common. Thus triggering this release.