### PR TITLE
fix: bump github artifact actions to v4

### DIFF
--- a/.github/workflows/IJ-latest.yml
+++ b/.github/workflows/IJ-latest.yml
@@ -24,7 +24,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build --continue -PideaVersion=LATEST-EAP-SNAPSHOT
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-reports


### PR DESCRIPTION
github artifact actions v2 [wont be usable](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) any longer this November:
>Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).