### PR TITLE
fix: bump kubernetes-client to 7.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
-kubernetes-client = "7.0.0"
+kubernetes-client = "7.1.0"
 jackson-core = "2.17.0"
 commons-lang3 = "3.12.0"
 commons-exec = "1.3"


### PR DESCRIPTION
bumps the kubernetes client to the latest stable version currently, 7.1.0